### PR TITLE
Fix bug that causes LHAPDF to crash

### DIFF
--- a/src/PDF/PDFLIB.cxx
+++ b/src/PDF/PDFLIB.cxx
@@ -73,7 +73,9 @@ void PDFLIB::Initialize(void) const
   const char * lhapath = gSystem->Getenv("LHAPATH");
   if(!lhapath) lhapath_ok = false;
   else {
-    if(!gSystem->OpenDirectory(lhapath)) lhapath_ok = false;
+   void *dirp = gSystem->OpenDirectory(lhapath);
+   if (dirp) gSystem->FreeDirectory(dirp);
+   else lhapath_ok = false;
   }
   if(!lhapath_ok) {
    LOG("PDF", pFATAL) 


### PR DESCRIPTION
This bug was discovered when trying to use T2KReWeight on GENIE files. It seems that the directory that was opened was never closed, so at one point the total number of "open directories" exceeded the current limit for gSystem (bash: ulimit -S -n), causing LHAPDF to crash. If the directory is freed every time we pass that line, the error does not occur. Thanks to Jacek M. Holeczek for proposing this solution!